### PR TITLE
Adjust registration request to match current apiserver api

### DIFF
--- a/register.go
+++ b/register.go
@@ -10,17 +10,23 @@ import (
 	"net/http"
 )
 
+type Meta struct {
+	Name string `json:"name,omitempty"`
+}
+
 type Minion struct {
-	Kind   string `json:"kind,omitempty"`
-	ID     string `json:"id,omitempty"`
-	HostIP string `json:"hostIP,omitempty"`
+	Kind     string `json:"kind,omitempty"`
+	ID       string `json:"id,omitempty"`
+	Metadata Meta   `json:"metadata,omitempty"`
+	HostIP   string `json:"hostIP,omitempty"`
 }
 
 func register(endpoint, addr string) error {
 	m := &Minion{
-		Kind:   "Minion",
-		ID:     addr,
-		HostIP: addr,
+		Kind:     "Minion",
+		ID:       addr,
+		Metadata: Meta{Name: addr},
+		HostIP:   addr,
 	}
 	data, err := json.Marshal(m)
 	if err != nil {

--- a/register.go
+++ b/register.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 )
@@ -35,5 +36,10 @@ func register(endpoint, addr string) error {
 		log.Printf("registered machine: %s\n", addr)
 		return nil
 	}
-	return errors.New("error registering: " + addr)
+	body, err := ioutil.ReadAll(res.Body)
+	reason := ""
+	if err == nil {
+		reason = ": " + string(body)
+	}
+	return errors.New("error registering: " + addr + reason)
 }


### PR DESCRIPTION
I was getting `error registering` errors from kube-register until `metadata.name` were introduced on kube-register side.

    Nov 13 23:50:27 ip-10-21-2-147.eu-west-1.compute.internal kube-register[25777]: error registering: 10.21.2.146: {"kind":"Status","creationTimestamp":null,"apiVersion":"v1beta1","status":"Failure","message":"minion \"\" is invalid: name: required value ''","reason":"Invalid","details":{"kind":"minion","causes":[{"reason":"FieldValueRequired","message":"name: required value ''","field":"name"}]},"code":422}
