### PR TITLE
adding reverse lookup to register hosts optionally by name and not by ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ Register Kubernetes Kubelet machines with the Kubernetes API server using Fleet 
 ## Usage
 
 ```
-kube-register -metadata="kubelet=true" -fleet-endpoint="http://127.0.0.1:4002" -apiserver-endpoint="http://127.0.0.1:8080"
+kube-register -metadata="kubelet=true" -fleet-endpoint="http://127.0.0.1:4002" -apiserver-endpoint="http://127.0.0.1:8080" -reverse-lookup=false
 ```
+
+By default kube-register registers new machines with their public IP addresses, found in fleet. By setting `-reverse-lookup=true` kube-register will do a reverse DNS lookup to get the machine's hostname and registers the machine with its hostname instead with its IP address. Make sure the machine's IP resolves to the same hostname that is printed by `hostname -f` on the machine itself.
 
 ## Building
 

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ var (
 	apiEndpoint   string
 	fleetEndpoint string
 	metadata      string
+	reverseLookup bool
 	syncInterval  int
 )
 
@@ -22,6 +23,7 @@ func init() {
 	flag.StringVar(&apiEndpoint, "api-endpoint", "", "kubernetes API endpoint")
 	flag.StringVar(&fleetEndpoint, "fleet-endpoint", "", "fleet endpoint")
 	flag.StringVar(&metadata, "metadata", "k8s=kubelet", "comma-delimited key/value pairs")
+	flag.BoolVar(&reverseLookup, "reverse-lookup", false, "execute reverse lookup for registering hostnames instead of hosts' public IPs")
 	flag.IntVar(&syncInterval, "sync-interval", 30, "sync interval")
 }
 
@@ -34,7 +36,7 @@ func main() {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 	for {
-		machines, err := getMachines(fleetEndpoint, m)
+		machines, err := getMachines(fleetEndpoint, m, reverseLookup)
 		if err != nil {
 			log.Println(err)
 		}

--- a/register.go
+++ b/register.go
@@ -5,24 +5,24 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-        "io/ioutil"
+	"io/ioutil"
 	"log"
 	"net/http"
 )
 
 type Minion struct {
-	Kind   string `json:"kind,omitempty"`
-	ID     string `json:"id,omitempty"`
-	HostIP string `json:"hostIP,omitempty"`
-        APIVersion string `json:"apiVersion,omitempty"`
+	Kind       string `json:"kind,omitempty"`
+	ID         string `json:"id,omitempty"`
+	HostIP     string `json:"hostIP,omitempty"`
+	APIVersion string `json:"apiVersion,omitempty"`
 }
 
 func register(endpoint, addr string) error {
 	m := &Minion{
-		Kind:   "Minion",
-                APIVersion: "v1beta1",
-		ID:     addr,
-		HostIP: addr,
+		Kind:       "Minion",
+		APIVersion: "v1beta1",
+		ID:         addr,
+		HostIP:     addr,
 	}
 	data, err := json.Marshal(m)
 	if err != nil {
@@ -38,8 +38,8 @@ func register(endpoint, addr string) error {
 		log.Printf("registered machine: %s\n", addr)
 		return nil
 	}
-        data, err = ioutil.ReadAll(res.Body)
-        log.Printf("Response: %#v", res)
-        log.Printf("Response Body:\n%s", string(data))
+	data, err = ioutil.ReadAll(res.Body)
+	log.Printf("Response: %#v", res)
+	log.Printf("Response Body:\n%s", string(data))
 	return errors.New("error registering: " + addr)
 }


### PR DESCRIPTION
if your DNS knows the machines' correct hostnames and you set `-reverse-lookup=true` you dont need to set `-hostname_override=${DEFAULT_IPV4}` when starting the kubelet service on the node.